### PR TITLE
✨ feat: add GitHub Actions workflow to trigger Jenkins job for release notes microservice

### DIFF
--- a/.github/workflows/jenkins-trigger-release-notes
+++ b/.github/workflows/jenkins-trigger-release-notes
@@ -1,0 +1,29 @@
+name: Trigger Jenkins Job Release Notes Microservice
+
+on:
+  push:
+    branches:
+      - "main-release-notes-microservice"
+  pull_request:
+    branches:
+      - "main-release-notes-microservice"
+  workflow_dispatch:
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build Jenkins URL
+        run: |
+          JENKINS_URL="https://automation.prms.cgiar.org/job/release-notes-microservices/build"
+          echo "Jenkins job URL: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to trigger a Jenkins job for the release notes microservice. The key changes include the addition of a new workflow file that defines the conditions for triggering the Jenkins job and the steps to execute it.

New GitHub Actions workflow:

* [`.github/workflows/jenkins-trigger-release-notes`](diffhunk://#diff-43f688038e053d2fb0cd39b469888d3a0b1261867f36d3e8ca3d18b894ba78e8R1-R29): Added a new workflow to trigger a Jenkins job on push, pull request, or manual dispatch events for the `main-release-notes-microservice` branch. The workflow includes steps to build the Jenkins URL and trigger the Jenkins job using credentials stored in GitHub secrets.