### PR TITLE
Dev release notes microservice

### DIFF
--- a/.github/workflows/jenkins-trigger-release-notes
+++ b/.github/workflows/jenkins-trigger-release-notes
@@ -1,0 +1,29 @@
+name: Trigger Jenkins Job Release Notes Microservice
+
+on:
+  push:
+    branches:
+      - "main-release-notes-microservice"
+  pull_request:
+    branches:
+      - "main-release-notes-microservice"
+  workflow_dispatch:
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build Jenkins URL
+        run: |
+          JENKINS_URL="https://automation.prms.cgiar.org/job/release-notes-microservices/build"
+          echo "Jenkins job URL: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to trigger a Jenkins job for the release notes microservice. The most important changes include setting up the workflow configuration, specifying the branches to monitor, and defining the steps to build the Jenkins URL and trigger the Jenkins job.

GitHub Actions workflow configuration:

* [`.github/workflows/jenkins-trigger-release-notes`](diffhunk://#diff-43f688038e053d2fb0cd39b469888d3a0b1261867f36d3e8ca3d18b894ba78e8R1-R29): Added a new workflow named "Trigger Jenkins Job Release Notes Microservice" that triggers on pushes and pull requests to the `main-release-notes-microservice` branch, as well as manual dispatches.

Steps to trigger Jenkins job:

* [`.github/workflows/jenkins-trigger-release-notes`](diffhunk://#diff-43f688038e053d2fb0cd39b469888d3a0b1261867f36d3e8ca3d18b894ba78e8R1-R29): Added steps to build the Jenkins URL and trigger the Jenkins job using the `curl` command, with environment variables for Jenkins credentials.