### PR TITLE
✨ fix(workflow): Update GitHub Actions workflow to trigger on dev-mining branch instead of main-mining

### DIFF
--- a/.github/workflows/jenkins-trigger-ai-text-mining.yml
+++ b/.github/workflows/jenkins-trigger-ai-text-mining.yml
@@ -3,10 +3,10 @@ name: Trigger Jenkins Job AI Text Mining Microservice
 on:
   push:
     branches:
-      - "main-mining" # Only on push to main-mining
+      - "dev-mining" # Only on push to main-mining
   pull_request:
     branches:
-      - "main-mining" # Only on PR to main-mining
+      - "dev-mining" # Only on PR to main-mining
   workflow_dispatch: # Allows manual trigger if needed
 
 jobs:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/jenkins-trigger-ai-text-mining.yml` file. The branch names for triggering the Jenkins job have been updated.

Branch updates for triggering Jenkins job:

* [`.github/workflows/jenkins-trigger-ai-text-mining.yml`](diffhunk://#diff-e516ad51bdc63de9752aa4f040dcd432b4c2f3088def64062c99d0733f09bb12L6-R9): Changed the branch names from `main-mining` to `dev-mining` for both push and pull request triggers.