### PR TITLE
✨ feat(docker): Add .dockerignore to exclude unnecessary files and directories from the Docker image

### DIFF
--- a/mining-microservice/.dockerignore
+++ b/mining-microservice/.dockerignore
@@ -1,0 +1,34 @@
+# Carpetas que no necesitas en la imagen
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+
+# Archivos de entorno y credenciales
+.env
+.env.*
+
+# Archivos de configuración de IDEs/editors
+.vscode/
+.idea/
+*.swp
+
+# Git
+.git/
+.gitignore
+
+# Archivos de sistema
+.DS_Store
+Thumbs.db
+
+# Logs y resultados
+*.log
+logs/
+data/logs/
+
+# Archivos temporales
+*.tmp
+*.bak
+*.old


### PR DESCRIPTION
This pull request includes changes to the `mining-microservice/.dockerignore` file to exclude unnecessary files and directories from the Docker image. The most important changes include excluding cache files, environment and credential files, IDE/editor configuration files, Git-related files, system files, logs, and temporary files.

Exclusions in `.dockerignore`:

* Cache files: `__pycache__/`, `*.pyc`, `*.pyo`, `*.pyd`, `*.db`, `*.sqlite3`
* Environment and credential files: `.env`, `.env.*`
* IDE/editor configuration files: `.vscode/`, `.idea/`, `*.swp`
* Git-related files: `.git/`, `.gitignore`
* System files: `.DS_Store`, `Thumbs.db`
* Logs and results: `*.log`, `logs/`, `data/logs/`
* Temporary files: `*.tmp`, `*.bak`, `*.old`