### PR TITLE
✨ fix(workflow): Update Jenkins trigger workflow to listen on main-mining branch instead of dev-mining

### DIFF
--- a/.github/workflows/jenkins-trigger-ai-text-mining.yml
+++ b/.github/workflows/jenkins-trigger-ai-text-mining.yml
@@ -3,10 +3,10 @@ name: Trigger Jenkins Job AI Text Mining Microservice
 on:
   push:
     branches:
-      - "dev-mining" # Only on push to main-mining
+      - "main-mining" # Only on push to main-mining
   pull_request:
     branches:
-      - "dev-mining" # Only on PR to main-mining
+      - "main-mining" # Only on PR to main-mining
   workflow_dispatch: # Allows manual trigger if needed
 
 jobs:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/jenkins-trigger-ai-text-mining.yml` file. The change updates the branches that trigger the Jenkins job for the AI Text Mining Microservice.

Branch update:

* The branch names in the `push` and `pull_request` triggers have been changed from `dev-mining` to `main-mining`.