### PR TITLE
✨Feat: add GitHub Actions workflow to trigger Jenkins job for auth microservice

### DIFF
--- a/.github/workflows/jenkins-trigger-auth-microservice.yml
+++ b/.github/workflows/jenkins-trigger-auth-microservice.yml
@@ -1,0 +1,31 @@
+name: Trigger Jenkins Job AUTH Microservice
+
+on:
+  push:
+    branches:
+      - "main-auth"
+  pull_request:
+    branches:
+      - "main-auth"
+  workflow_dispatch:
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Build Jenkins URL
+      - name: Build Jenkins URL
+        run: |
+          JENKINS_URL="https://automation.prms.cgiar.org/job/auth-microservice/build"
+          echo "Jenkins job URL: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+
+      # Step 2: Trigger Jenkins Job
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the triggering of a Jenkins job for the AUTH microservice. The workflow is designed to respond to specific Git events and includes steps for constructing the Jenkins URL and triggering the job.

### New GitHub Actions Workflow:

* [`.github/workflows/jenkins-trigger-auth-microservice.yml`](diffhunk://#diff-05393190a60ce52345a1ac38eaad96294c8ff96730d8397dd362a2f460d56c59R1-R31): Added a new workflow named "Trigger Jenkins Job AUTH Microservice." It triggers on `push` and `pull_request` events targeting the `main-auth` branch, as well as on manual dispatch (`workflow_dispatch`). The workflow builds the Jenkins job URL and triggers the job using credentials stored in GitHub Secrets.