### PR TITLE
✨ feat(ci): update Jenkins trigger workflow to dynamically build job URL based on branch name

### DIFF
--- a/.github/workflows/jenkins-trigger-auth-microservice.yml
+++ b/.github/workflows/jenkins-trigger-auth-microservice.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - "main-auth"
+      - "dev-auth"
   pull_request:
     branches:
       - "main-auth"
+      - "dev-auth"
   workflow_dispatch:
 
 jobs:
@@ -17,7 +19,8 @@ jobs:
       # Step 1: Build Jenkins URL
       - name: Build Jenkins URL
         run: |
-          JENKINS_URL="https://automation.prms.cgiar.org/job/auth-microservice/build"
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
+          JENKINS_URL="https://automation.prms.cgiar.org/job/auth-microservice-${BRANCH_NAME}/build"
           echo "Jenkins job URL: $JENKINS_URL"
           echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the `auth-microservice` to support the `dev-auth` branch and dynamically construct the Jenkins job URL based on the branch name. These changes enhance the workflow's flexibility and adaptability for multiple branches.

### Workflow updates for branch support:

* [`.github/workflows/jenkins-trigger-auth-microservice.yml`](diffhunk://#diff-05393190a60ce52345a1ac38eaad96294c8ff96730d8397dd362a2f460d56c59R7-R11): Added support for the `dev-auth` branch in both `push` and `pull_request` triggers.

### Jenkins URL construction:

* [`.github/workflows/jenkins-trigger-auth-microservice.yml`](diffhunk://#diff-05393190a60ce52345a1ac38eaad96294c8ff96730d8397dd362a2f460d56c59L20-R23): Updated the "Build Jenkins URL" step to dynamically construct the Jenkins job URL using the branch name extracted from `GITHUB_REF`. This ensures the correct Jenkins job is triggered for each branch.